### PR TITLE
Remove second variable for log message on ec2 remediation lambda

### DIFF
--- a/site/amazon-guard-duty-revamped-v1.yml
+++ b/site/amazon-guard-duty-revamped-v1.yml
@@ -789,7 +789,7 @@ Resources:
 
               if instanceID == os.environ['INSTANCE_ID']:
 
-                print("log -- Security Group Created %s in vpc %s." % (security_group_id))
+                print("log -- Security Group Created %s." % (security_group_id))
 
                 # Isolate Instance
                 ec2 = boto3.resource('ec2')

--- a/site/amazon-guard-duty-revamped-v1.yml
+++ b/site/amazon-guard-duty-revamped-v1.yml
@@ -789,7 +789,7 @@ Resources:
 
               if instanceID == os.environ['INSTANCE_ID']:
 
-                print("log -- Security Group Created %s." % (security_group_id))
+                print("log -- Security Group Created %s." % security_group_id)
 
                 # Isolate Instance
                 ec2 = boto3.resource('ec2')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The vpc_id was removed from the remediation Lambda, but the log message referencing the security_group_id and vpc_id was left. Removed the second variable in the log message that was causing the error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
