### PR TITLE
Updating CFN file to fix issue with deployment failing

### DIFF
--- a/docs/amazon-guard-duty-revamped-v2.yml
+++ b/docs/amazon-guard-duty-revamped-v2.yml
@@ -105,6 +105,10 @@ Resources:
       VpcId: !Ref VPC
   PublicRoute:
     Type: AWS::EC2::Route
+    DependsOn:
+      - VPC
+      - InternetGateway
+      - RouteTable
     Properties:
       DestinationCidrBlock: 0.0.0.0/0
       GatewayId: !Ref InternetGateway


### PR DESCRIPTION
*Description of changes:*

Adding depends-on for the PublicRoute element in the CFN, as when I attempted to deploy it to a blank account I got the following error: 

`route table rtb-ID and network gateway igw-ID belong to different networks (Service: AmazonEC2; Status Code: 400; Error Code: InvalidParameterValue; Request ID: ID; Proxy: null)`

Adding the depends statement to the CFN fixes the race condition.

Please ping me internally (tomgray@) if you have any questions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
